### PR TITLE
Change handling of static files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Django stuff:
 *.log
 local_settings.py
+# ignore root static directory populated by collectstatic (mind leading '/')
+/static
 
 # Python virtualenv
 .venv
@@ -21,5 +23,8 @@ lib/galaxy.egg-info
 
 # misc.
 .tox
+
+# ignore linked external css file
+training/static/training/style/galaxy.css
 
 # TODO as needed: static, documentation build files, etc.

--- a/training/static/training/style/tiaas.css
+++ b/training/static/training/style/tiaas.css
@@ -1,1 +1,62 @@
 /* add custom css to overwrite galaxy.css here */
+
+/* base.html */
+#center {
+  padding-right: 10em;
+  padding-left: 10em;
+  overflow-y: auto;
+}
+
+#everything {
+  overflow-y: scroll!important;
+}
+
+#center {
+  padding-top: 3em;
+  overflow-y: scroll!important;
+}
+
+#columns .text-center {
+  margin: 3em 0;
+  border-top: 1px solid gray;
+  padding: 1em;
+}
+
+/*  about.html  */
+.btn_apply {
+  font-size: 200%;
+  font-weight: 900;
+  border: 1px solid black;
+  padding: 0.5em;
+}
+
+.tiaas_logo {
+  margin: 1em;
+  width: 22em;
+}
+
+/* register.html */
+.register {
+  font-size: 16px;
+}
+
+.register .editable {
+  border-left: 4px solid gold;
+  padding-left: 1em;
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+
+.register .row.bootstrap3-multi-input {
+  margin-left: 0px;
+}
+
+.register .control-label{
+  font-weight: 900;
+  font-size: 115%
+}
+
+/* calendar.html */
+.calendar .date {
+  padding: 0.3em;
+}

--- a/training/static/training/style/tiaas.css
+++ b/training/static/training/style/tiaas.css
@@ -1,0 +1,1 @@
+/* add custom css to overwrite galaxy.css here */

--- a/training/templates/base.html
+++ b/training/templates/base.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!DOCTYPE HTML>
 <html>
 <head>
@@ -5,9 +6,8 @@
 	<meta name="viewport" content="maximum-scale=1.0">
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
 	<title>Galaxy TIaaS {% block title %}{% endblock %}</title>
-	<link href="{{ config.redirect_location }}/static/style/base.css" media="screen" rel="stylesheet" type="text/css" />
-	<link href="{{ config.redirect_location }}/static/dist/base.css" media="screen" rel="stylesheet" type="text/css" />
-
+    <link  href="{% static 'training/style/galaxy.css' %}" media="screen" rel="stylesheet" type="text/css" />
+    <link  href="{% static 'training/style/tiaas.css' %}" media="screen" rel="stylesheet" type="text/css" />
 	<style type="text/css" media="all">
 		#center{ padding-right: 10em; padding-left: 10em; overflow-y: auto; }
 	</style>

--- a/training/templates/base.html
+++ b/training/templates/base.html
@@ -8,16 +8,12 @@
 	<title>Galaxy TIaaS {% block title %}{% endblock %}</title>
     <link  href="{% static 'training/style/galaxy.css' %}" media="screen" rel="stylesheet" type="text/css" />
     <link  href="{% static 'training/style/tiaas.css' %}" media="screen" rel="stylesheet" type="text/css" />
-	<style type="text/css" media="all">
-		#center{ padding-right: 10em; padding-left: 10em; overflow-y: auto; }
-	</style>
 	{% if refresh %}
 	<meta http-equiv="refresh" content="5">
 	{% endif %}
 </head>
-
 <body scroll="no" class="full-content ">
-	<div id="everything" style="overflow-y: scroll!important">
+    <div id="everything">
 		<nav id="masthead" class="navbar navbar-expand justify-content-center navbar-dark">
 			<a class="navbar-brand" href="/">
 				<span class="navbar-brand-title">Galaxy Training Infrastructure as a Service</span>
@@ -25,16 +21,16 @@
 		</nav>
 
 		<div id="columns">
-			<div id="center" class="inbound" style="padding-top: 3em; overflow-y: scroll!important">
+            <div id="center" class="inbound">
 				{% block content %}
 				{% endblock %}
 
-				<div class="text-center" style="margin: 3em 0;border-top: 1px solid gray;padding: 1em;">
-					<b>Training Infrastructure as a Service (TIaaS)</b> licensed under the AGPLv3, running commit <a href="https://github.com/usegalaxy-eu/tiaas2/commit/{{ settings.GIT_COMMIT_ID }}" target="_blank">{{ settings.GIT_COMMIT_ID }}</a>
+                <div class="text-center"> 
+					<b>Training Infrastructure as a Service (TIaaS)</b> licensed under the AGPLv3, running commit
+                    <a href="https://github.com/usegalaxy-eu/tiaas2/commit/{{ settings.GIT_COMMIT_ID }}" target="_blank">{{ settings.GIT_COMMIT_ID }}</a>
 				</div>
 			</div><!--end center-->
 		</div><!--end columns-->
 	</div><!--end everything-->
 </body>
 </html>
-

--- a/training/templates/base.html
+++ b/training/templates/base.html
@@ -2,35 +2,33 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-	<meta name="viewport" content="maximum-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
-	<title>Galaxy TIaaS {% block title %}{% endblock %}</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="maximum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
+    <title>Galaxy TIaaS {% block title %}{% endblock %}</title>
     <link  href="{% static 'training/style/galaxy.css' %}" media="screen" rel="stylesheet" type="text/css" />
     <link  href="{% static 'training/style/tiaas.css' %}" media="screen" rel="stylesheet" type="text/css" />
-	{% if refresh %}
-	<meta http-equiv="refresh" content="5">
-	{% endif %}
+    {% if refresh %}
+    <meta http-equiv="refresh" content="5">
+    {% endif %}
 </head>
 <body scroll="no" class="full-content ">
     <div id="everything">
-		<nav id="masthead" class="navbar navbar-expand justify-content-center navbar-dark">
-			<a class="navbar-brand" href="/">
-				<span class="navbar-brand-title">Galaxy Training Infrastructure as a Service</span>
-			</a>
-		</nav>
-
-		<div id="columns">
+        <nav id="masthead" class="navbar navbar-expand justify-content-center navbar-dark">
+            <a class="navbar-brand" href="/">
+            	<span class="navbar-brand-title">Galaxy Training Infrastructure as a Service</span>
+            </a>
+        </nav>
+        <div id="columns">
             <div id="center" class="inbound">
-				{% block content %}
-				{% endblock %}
-
+                {% block content %}
+                {% endblock %}
                 <div class="text-center"> 
-					<b>Training Infrastructure as a Service (TIaaS)</b> licensed under the AGPLv3, running commit
+                    <b>Training Infrastructure as a Service (TIaaS)</b> licensed under the AGPLv3, running commit
                     <a href="https://github.com/usegalaxy-eu/tiaas2/commit/{{ settings.GIT_COMMIT_ID }}" target="_blank">{{ settings.GIT_COMMIT_ID }}</a>
-				</div>
-			</div><!--end center-->
-		</div><!--end columns-->
-	</div><!--end everything-->
+                </div>
+            </div><!--end center-->
+        </div><!--end columns-->
+    </div><!--end everything-->
 </body>
 </html>

--- a/training/templates/training/about.html
+++ b/training/templates/training/about.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <h1>TIaaS</h1>
-<p><img src="https://galaxyproject.eu/assets/media/tiaas-logo.png" alt="tiaas logo depicting people in queues" width="300em" style="margin: 1em"></p>
+<p><img src="https://galaxyproject.eu/assets/media/tiaas-logo.png" alt="tiaas logo depicting people in queues" class="tiaas_logo"></p>
 <p><a href="https://usegalaxy.eu">UseGalaxy.eu</a> is proud to provide Training Infrastructure as a Service (TIaaS) for the Galaxy training community. You provide the training, we provide the infrastructure <i>at no cost</i>.</p>
 <h2 id="why-tiaas">Why TIaaS?</h2>
 
@@ -30,7 +30,7 @@
 <p>We have significant capacity and have dedicated some of this to providing training using our service. Anyone providing training on using Galaxy is eligible to request the use of this service.</p>
 
 <p>
-<a style="font-size: 200%;font-weight: 900;border: 1px solid black;padding: 0.5em;" href="{% url 'register' %}">Apply now!</a>
+<a class="btn_apply" href="{% url 'register' %}">Apply now!</a>
 </p>
 
 <h2>Stats</h2>

--- a/training/templates/training/calendar.html
+++ b/training/templates/training/calendar.html
@@ -7,52 +7,36 @@
 {% for year, months in days.items %}
 <h3>{{ year }}</h3>
 <div class="row">
-	{% for month, days in months.items %}
-	<div class="col-sm-3 text-center calendar">
-		{{ month }}
-
-		<div class="row">
-                <div class="col-sm-1 date">
-					M
-				</div>
-                <div class="col-sm-1 date">
-					T
-				</div>
-                <div class="col-sm-1 date">
-					W
-				</div>
-                <div class="col-sm-1 date">
-					R
-				</div>
-                <div class="col-sm-1 date">
-					F
-				</div>
-				<div class="col-sm-1 date">
-					S
-				</div>
-				<div class="col-sm-1 date">
-					S
-				</div>
-		</div>
-
-		{% for row in days %}
-		<div class="row">
-			{% for d in row %}
-				{% if d.0 == 0 %}
-                <div class="col-sm-1 date">
-				</div>
-				{% else %}
-
-				{% widthratio d.1 max_value 83 as width%}
-				<div class="col-sm-1 date" style="background-color:hsla(220, 100%, 30%, 0.{{ width|add:"0"|stringformat:"02d" }});">
-					{{ d.1 }}
-				</div>
-				{% endif %}
-			{% endfor %}
-		</div>
-		{% endfor %}
-	</div>
-	{% endfor %}
+    {% for month, days in months.items %}
+    <div class="col-sm-3 text-center calendar">
+        {{ month }}
+        
+        <div class="row">
+            <div class="col-sm-1 date">M</div>
+            <div class="col-sm-1 date">T</div>
+            <div class="col-sm-1 date">W</div>
+            <div class="col-sm-1 date">R</div>
+            <div class="col-sm-1 date">F</div>
+            <div class="col-sm-1 date">S</div>
+            <div class="col-sm-1 date">S</div>
+        </div>
+        
+        {% for row in days %}
+        <div class="row">
+            {% for d in row %}
+                {% if d.0 == 0 %}
+                <div class="col-sm-1 date"></div>
+                {% else %}
+                {% widthratio d.1 max_value 83 as width%}
+                <div class="col-sm-1 date" style="background-color:hsla(220, 100%, 30%, 0.{{ width|add:"0"|stringformat:"02d" }});">
+                    {{ d.1 }}
+                </div>
+                {% endif %}
+            {% endfor %}
+        </div>
+        {% endfor %}
+    </div>
+    {% endfor %}
 </div>
 {% endfor %}
 

--- a/training/templates/training/calendar.html
+++ b/training/templates/training/calendar.html
@@ -8,29 +8,29 @@
 <h3>{{ year }}</h3>
 <div class="row">
 	{% for month, days in months.items %}
-	<div class="col-sm-3 text-center">
+	<div class="col-sm-3 text-center calendar">
 		{{ month }}
 
 		<div class="row">
-				<div class="col-sm-1" style="padding: 0.3em;">
+                <div class="col-sm-1 date">
 					M
 				</div>
-				<div class="col-sm-1" style="padding: 0.3em;">
+                <div class="col-sm-1 date">
 					T
 				</div>
-				<div class="col-sm-1" style="padding: 0.3em;">
+                <div class="col-sm-1 date">
 					W
 				</div>
-				<div class="col-sm-1" style="padding: 0.3em;">
+                <div class="col-sm-1 date">
 					R
 				</div>
-				<div class="col-sm-1" style="padding: 0.3em;">
+                <div class="col-sm-1 date">
 					F
 				</div>
-				<div class="col-sm-1" style="padding: 0.3em;">
+				<div class="col-sm-1 date">
 					S
 				</div>
-				<div class="col-sm-1" style="padding: 0.3em;">
+				<div class="col-sm-1 date">
 					S
 				</div>
 		</div>
@@ -39,12 +39,12 @@
 		<div class="row">
 			{% for d in row %}
 				{% if d.0 == 0 %}
-				<div class="col-sm-1" style="padding: 0.3em;">
+                <div class="col-sm-1 date">
 				</div>
 				{% else %}
 
 				{% widthratio d.1 max_value 83 as width%}
-				<div class="col-sm-1" style="background-color:hsla(220, 100%, 30%, 0.{{ width|add:"0"|stringformat:"02d"  }}); padding: 0.3em;">
+				<div class="col-sm-1 date" style="background-color:hsla(220, 100%, 30%, 0.{{ width|add:"0"|stringformat:"02d" }});">
 					{{ d.1 }}
 				</div>
 				{% endif %}

--- a/training/templates/training/error.html
+++ b/training/templates/training/error.html
@@ -3,9 +3,9 @@
 {% block content %}
 
 <div class="errormessage">
-	Error {{ message }}	
-	<br />
-	<a href="https://{{ host }}">Return to Galaxy</a>
+    Error {{ message }}	
+    <br />
+    <a href="https://{{ host }}">Return to Galaxy</a>
 </div>
 
 

--- a/training/templates/training/join.html
+++ b/training/templates/training/join.html
@@ -3,8 +3,8 @@
 {% block content %}
 
 <div class="donemessage">
-	Congratulations: you are successfully registered in <b>{{ training.training_identifier }}</b><br/>
-	<a href="https://{{ host }}">Return to Galaxy</a>
+    Congratulations: you are successfully registered in <b>{{ training.training_identifier }}</b><br/>
+    <a href="https://{{ host }}">Return to Galaxy</a>
 </div>
 
 <h2>How It Works</h2>

--- a/training/templates/training/register.html
+++ b/training/templates/training/register.html
@@ -3,27 +3,7 @@
 
 {% block content %}
 
-<style type="text/css" media="all">
-form {
-	font-size: 16px;
-}
-.editable {
-	border-left: 4px solid gold;
-	padding-left: 1em;
-	margin-top: 1em;
-	margin-bottom: 1em;
-}
-
-  .row.bootstrap3-multi-input {
-	  margin-left: 0px;
-  }
-
-  .control-label{
-	  font-weight: 900;
-		  font-size: 115%
-  }
-</style>
-<form action="{% url 'register' %}" method="post" class="form">
+<form action="{% url 'register' %}" method="post" class="form register">
   {% csrf_token %}
 
   <h1>{{ settings.TIAAS_OWNER }}'s Training Infrastructure as a Service</h1>

--- a/training/templates/training/stats.html
+++ b/training/templates/training/stats.html
@@ -10,38 +10,36 @@ Data is cumulative since {{ earliest }}
   <div class="col-sm-3">
     <div class="card">
       <div class="card-body">
-		  <h1 class="card-title">{{ approved }} Events</h1>
-		  <p class="card-text">With {{ waiting }} new training requests waiting</p>
+        <h1 class="card-title">{{ approved }} Events</h1>
+        <p class="card-text">With {{ waiting }} new training requests waiting</p>
       </div>
     </div>
   </div>
   <div class="col-sm-3">
     <div class="card">
       <div class="card-body">
-		  <h1 class="card-title">{{ current_trainings }} Events Today!</h1>
-		  <p class="card-text">Currently active training events</p>
+        <h1 class="card-title">{{ current_trainings }} Events Today!</h1>
+        <p class="card-text">Currently active training events</p>
       </div>
     </div>
   </div>
   <div class="col-sm-3">
     <div class="card">
       <div class="card-body">
-		  <h1 class="card-title">{{ students }} Students</h1>
-		  <p class="card-text">taught over the lifetime of the TIaaS service</p>
+        <h1 class="card-title">{{ students }} Students</h1>
+        <p class="card-text">taught over the lifetime of the TIaaS service</p>
       </div>
     </div>
   </div>
   <div class="col-sm-3">
     <div class="card">
       <div class="card-body">
-		  <h1 class="card-title">{{ days }} Days</h1>
-		  <p class="card-text">Total number of days for which we have provided VMs to various training events.</p>
+        <h1 class="card-title">{{ days }} Days</h1>
+        <p class="card-text">Total number of days for which we have provided VMs to various training events.</p>
       </div>
     </div>
   </div>
 </div>
-
-
 
 <script src="{% static "training/d3.v4.js" %}"></script>
 <script src="{% static "training/d3-scale-chromatic.v1.min.js" %}"></script>
@@ -51,20 +49,20 @@ Data is cumulative since {{ earliest }}
 </div>
 
 <table class="table table-striped">
-	<thead>
-		<tr>
-			<th>Country</th>
-			<th>Training events</th>
-		</tr>
-	</thead>
-	<tbody>
-		{% for k, v in locations.items  %}
-		<tr>
-			<td>{{ k }}</td>
-			<td>{{ v}}</td>
-		</tr>
-		{% endfor %}
-	</tbody>
+    <thead>
+        <tr>
+            <th>Country</th>
+            <th>Training events</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for k, v in locations.items  %}
+        <tr>
+            <td>{{ k }}</td>
+            <td>{{ v}}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
 </table>
 
 
@@ -93,10 +91,10 @@ d3.queue()
 
 function ready(error, topo) {
 
-	var colorScale = d3.scaleLinear()
-	.domain([0, d3.max(data.values())])
-	.range(["#eee", "#003399"])
-	console.log(d3.max(data));
+    var colorScale = d3.scaleLinear()
+    .domain([0, d3.max(data.values())])
+    .range(["#eee", "#003399"])
+    console.log(d3.max(data));
 
   // Draw the map
   svg.append("g")

--- a/training/templates/training/status.html
+++ b/training/templates/training/status.html
@@ -8,137 +8,137 @@
 {% block content %}
 <h2>Overview: {{ training.training_identifier }}</h2>
 <div class="row">
-	<div class="col-md-3 col-sm-12">
-		<h3>About</h3>
-		<p>
-		This page gives you a brief overview of the current status of the trainees. Please note the following:
-		</p>
-		<ul>
-			<li>Only jobs created in the last 3 hours are shown</li>
-			<li>This includes jobs they run outside of the context of the course (as we cannot tell which are which.)</li>
-			<li>The username is essentially random but will be consistent within a one day period</li>
-		</ul>
-		Refresh:
-		<a href="?refresh">Auto</a> |
-		<a href="?">Off</a>
-		</br>
-		Last:
-		<a href="?hours=1">1 hour</a> |
-		<a href="?hours=3">3 hours</a> |
-		<a href="?hours=6">6 hours</a>
-		<h3>State Overview</h3>
-		<table class="table">
-			<thead>
-				<tr>
-					<th>Job State</th>
-					<th>Count</th>
-				</tr>
-			</thead>
-			{% for state, count  in state.items %}
-				{% if state != '__total__' %}
-				<tr>
-					<td>{{ state }}</td>
-					<td style="background: rgba(128, 128, 128, {{ count_percent }});">{{ count }}</td>
-				</tr>
-				{% endif %}
-			{% endfor %}
-		</table>
-		<table class="table">
-			<thead>
-				<tr>
-					<th>Workflow State</th>
-					<th>Count</th>
-				</tr>
-			</thead>
-			{% for state, count  in wf_state.items %}
-				{% if state != '__total__' %}
-				<tr>
-					<td>{{ state }}</td>
-					<td style="background: rgba(128, 128, 128, {{ count_percent }});">{{ count }}</td>
-				</tr>
-				{% endif %}
-			{% endfor %}
-		</table>
-	</div>
-	<div class="col-md-9 col-sm-12">
-		<h3>Students</h3>
-		<div>
-		{{ users | length }} Registered
-		</div>
-		<div style="padding-top: 1em;padding-bottom: 1em">
-		{% for user in users %}
-			<span style="background: #{{ user }};padding: 0.3em">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>&nbsp;
-		{% endfor %}
-		</div>
-
-		<h3>Overview by Tool</h3>
-		<table class="table">
-			<thead>
-				<tr>
-					<th>Tool</th>
-					<th>New</th>
-					<th>Queued</th>
-					<th>Running</th>
-					<th>Ok</th>
-					<th>Error</th>
-				</tr>
-			</thead>
-			{% for tool, states in jobs_overview.items %}
-				<tr>
-					<td>{{ tool }}</td>
-					<td style="background: rgba(128, 128, 128, {{ states.new_percent }});">{{ states.new }}</td>
-					<td style="background: rgba(128, 128, 128, {{ states.queued_percent }});">{{ states.queued }}</td>
-					<td style="background: rgba(128, 128, 128, {{ states.running_percent }});">{{ states.running }}</td>
-					<td style="background: rgba(128, 128, 128, {{ states.ok_percent }});">{{ states.ok }}</td>
-					<td style="background: rgba(128, 128, 128, {{ states.error_percent }});">{{ states.error }}</td>
-				</tr>
-			{% endfor %}
-		</table>
-	</div>
+    <div class="col-md-3 col-sm-12">
+        <h3>About</h3>
+        <p>
+        This page gives you a brief overview of the current status of the trainees. Please note the following:
+        </p>
+        <ul>
+            <li>Only jobs created in the last 3 hours are shown</li>
+            <li>This includes jobs they run outside of the context of the course (as we cannot tell which are which.)</li>
+            <li>The username is essentially random but will be consistent within a one day period</li>
+        </ul>
+        Refresh:
+        <a href="?refresh">Auto</a> |
+        <a href="?">Off</a>
+        </br>
+        Last:
+        <a href="?hours=1">1 hour</a> |
+        <a href="?hours=3">3 hours</a> |
+        <a href="?hours=6">6 hours</a>
+        <h3>State Overview</h3>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Job State</th>
+                    <th>Count</th>
+                </tr>
+            </thead>
+            {% for state, count  in state.items %}
+                {% if state != '__total__' %}
+                <tr>
+                    <td>{{ state }}</td>
+                    <td style="background: rgba(128, 128, 128, {{ count_percent }});">{{ count }}</td>
+                </tr>
+                {% endif %}
+            {% endfor %}
+        </table>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Workflow State</th>
+                    <th>Count</th>
+                </tr>
+            </thead>
+            {% for state, count  in wf_state.items %}
+                {% if state != '__total__' %}
+                <tr>
+                    <td>{{ state }}</td>
+                    <td style="background: rgba(128, 128, 128, {{ count_percent }});">{{ count }}</td>
+                </tr>
+                {% endif %}
+            {% endfor %}
+        </table>
+    </div>
+    <div class="col-md-9 col-sm-12">
+        <h3>Students</h3>
+        <div>
+        {{ users | length }} Registered
+        </div>
+        <div style="padding-top: 1em;padding-bottom: 1em">
+        {% for user in users %}
+            <span style="background: #{{ user }};padding: 0.3em">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>&nbsp;
+        {% endfor %}
+        </div>
+    
+        <h3>Overview by Tool</h3>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Tool</th>
+                    <th>New</th>
+                    <th>Queued</th>
+                    <th>Running</th>
+                    <th>Ok</th>
+                    <th>Error</th>
+                </tr>
+            </thead>
+            {% for tool, states in jobs_overview.items %}
+                <tr>
+                    <td>{{ tool }}</td>
+                    <td style="background: rgba(128, 128, 128, {{ states.new_percent }});">{{ states.new }}</td>
+                    <td style="background: rgba(128, 128, 128, {{ states.queued_percent }});">{{ states.queued }}</td>
+                    <td style="background: rgba(128, 128, 128, {{ states.running_percent }});">{{ states.running }}</td>
+                    <td style="background: rgba(128, 128, 128, {{ states.ok_percent }});">{{ states.ok }}</td>
+                    <td style="background: rgba(128, 128, 128, {{ states.error_percent }});">{{ states.error }}</td>
+                </tr>
+            {% endfor %}
+        </table>
+    </div>
 </div>
 
 <h2>Job Queue</h2>
 <table class="table">
-	<thead>
-		<tr>
-			<th>User</th>
-			<th>Created</th>
-			<th>Tool</th>
-			<th>State</th>
-			<th>Job Runner ID</th>
-		</tr>
-	</thead>
-	{% for row in jobs %}
-		<tr>
-			<td class="dataset" style="background: #{{ row.user_id }}">{{ row.user_id }}</td>
-			<td class="dataset state-{{row.state}}">{{ row.create_time | naturaltime }}</td>
-			<td class="dataset state-{{row.state}}">{{ row.tool_id }}</td>
-			<td class="dataset state-{{row.state}}">{{ row.state }}</td>
-			<td class="dataset state-{{row.state}}">{{ row.job_runner_external_id}}</td>
-		</tr>
-	{% endfor %}
+    <thead>
+        <tr>
+            <th>User</th>
+            <th>Created</th>
+            <th>Tool</th>
+            <th>State</th>
+            <th>Job Runner ID</th>
+        </tr>
+    </thead>
+    {% for row in jobs %}
+        <tr>
+            <td class="dataset" style="background: #{{ row.user_id }}">{{ row.user_id }}</td>
+            <td class="dataset state-{{row.state}}">{{ row.create_time | naturaltime }}</td>
+            <td class="dataset state-{{row.state}}">{{ row.tool_id }}</td>
+            <td class="dataset state-{{row.state}}">{{ row.state }}</td>
+            <td class="dataset state-{{row.state}}">{{ row.job_runner_external_id}}</td>
+        </tr>
+    {% endfor %}
 </table>
 
 <h2>Workflow Invocation Queue</h2>
 <table class="table">
-	<thead>
-		<tr>
-			<th>User</th>
-			<th>Created</th>
-			<th>Tool</th>
-			<th>State</th>
-			<th>Invocation ID</th>
-		</tr>
-	</thead>
-	{% for row in wfs %}
-		<tr>
-			<td class="dataset" style="background: #{{ row.user_id }}">{{ row.user_id }}</td>
-			<td class="dataset state-{% if row.state == "scheduled" %}ok{% endif %}">{{ row.create_time | naturaltime }}</td>
-			<td class="dataset state-{% if row.state == "scheduled" %}ok{% endif %}">{{ row.workflow_name }}</td>
-			<td class="dataset state-{% if row.state == "scheduled" %}ok{% endif %}">{{ row.state }}</td>
-			<td class="dataset state-{% if row.state == "scheduled" %}ok{% endif %}">{{ row.id }}</td>
-		</tr>
-	{% endfor %}
+    <thead>
+        <tr>
+            <th>User</th>
+            <th>Created</th>
+            <th>Tool</th>
+            <th>State</th>
+            <th>Invocation ID</th>
+        </tr>
+    </thead>
+    {% for row in wfs %}
+        <tr>
+            <td class="dataset" style="background: #{{ row.user_id }}">{{ row.user_id }}</td>
+            <td class="dataset state-{% if row.state == "scheduled" %}ok{% endif %}">{{ row.create_time | naturaltime }}</td>
+            <td class="dataset state-{% if row.state == "scheduled" %}ok{% endif %}">{{ row.workflow_name }}</td>
+            <td class="dataset state-{% if row.state == "scheduled" %}ok{% endif %}">{{ row.state }}</td>
+            <td class="dataset state-{% if row.state == "scheduled" %}ok{% endif %}">{{ row.id }}</td>
+        </tr>
+    {% endfor %}
 </table>
 
 {% endblock %}

--- a/training/templates/training/thanks.html
+++ b/training/templates/training/thanks.html
@@ -3,7 +3,7 @@
 {% block content %}
 
 <div class="donemessage">
-	Congratulations: you have successfully registered a training. We will write you soon with our decision.
+    Congratulations: you have successfully registered a training. We will write you soon with our decision.
 </div>
 
 


### PR DESCRIPTION
@hexylena how do you feel about this approach? 

1. `base.html` template assumes the existence of `galaxy.css` and
   `tiaas.css`. Both may or may not exist.
2. `galaxy.css` can be a symbolic link in `training/static/training/style/`
   pointing to the location of Galaxy's `base.css` (currently in
   `[galaxy root]/static/style/base.css`). It is not version controlled.
3. `tiass.css` is located in the same directory as `galaxy.css` and
   serves as the home to any custom styles that override the styles
   in `galaxy.css`.
4. Both files are copied to the root `static` directory by running
   the `collectstatic` app (see documentation for v. 3.1 here:
   https://docs.djangoproject.com/en/3.1/howto/static-files/ ).
   `collectstatic` should be run whenever any of these files is updated.

THOUGHTS/JUSTIFICATION:
It seems safer to have to occasionally run `collectstatic` to
update the linked Galaxy stylesheet versus to rely on it not to break
the app's layout.
Also, we are not guessing the location of `base.css`; local development is more streamlined, and it follows the approach suggested in the Django docs (which makes it easier for newcomers). 