### PR TITLE
Use owner_site instead of domain for link on about page

### DIFF
--- a/training/templates/training/about.html
+++ b/training/templates/training/about.html
@@ -4,7 +4,7 @@
 {% block content %}
 <h1>TIaaS</h1>
 <p><img src="https://galaxyproject.eu/assets/media/tiaas-logo.png" alt="tiaas logo depicting people in queues" width="300em" style="margin: 1em"></p>
-<p><a href="{{ settings.TIAAS_DOMAIN }}">{{ settings.TIAAS_OWNER }}</a> is proud to provide Training Infrastructure as a Service (TIaaS) for the Galaxy training community. You provide the training, we provide the infrastructure <i>at no cost</i>.</p>
+<p><a href="{{ settings.TIAAS_OWNER_SITE }}">{{ settings.TIAAS_OWNER }}</a> is proud to provide Training Infrastructure as a Service (TIaaS) for the Galaxy training community. You provide the training, we provide the infrastructure <i>at no cost</i>.</p>
 <h2 id="why-tiaas">Why TIaaS?</h2>
 
 <ul>


### PR DESCRIPTION
Pretty sure this is meant to be the "nice human name of your server" rather than the hostname.